### PR TITLE
Add accessibility checklist

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 ## Accessibility
 <!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->
 
--   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
--   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
--   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
--   [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
+- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
+- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
+- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
+- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,11 @@
 
 ## Images
 <!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
+
+## Accessibility
+<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->
+
+-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
+-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
+-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
+-   [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)


### PR DESCRIPTION
## What does this change?

Adds an accessibility checklist to the default PR template

## How can we measure success?

We are not currently tracking accessibility metrics centrally. Part of Client Side Tools and Infrastructure team's KRs for Q1 2021/22 are to determine the state of accessibility within P&E. We would hope to see improvements to the accessibility knowledge of our teams and the accessibility metrics for our products.
