### PR TITLE
Adds generic sbt node snyk workflow

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -1,0 +1,40 @@
+name: SBT Node Snyk
+
+on:
+  workflow_call:
+    inputs:
+      DEBUG:
+        type: string
+        required: false
+    secrets:
+      SNYK_TOKEN:
+        required: true
+
+jobs:
+    security:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout branch
+              uses: actions/checkout@v2
+
+            - name: Setup debug var
+              run: echo INPUT_DEBUG=${{ inputs.DEBUG }} >> $GITHUB_ENV
+              shell: bash
+
+            - name: Get node version
+              run: echo NODE_VERSION=$(cat .nvmrc) >> $GITHUB_ENV
+
+            - uses: snyk/actions/setup@0.3.0
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+
+            - uses: actions/setup-java@v2
+              with:
+                  java-version: "8"
+                  distribution: "adopt"
+
+            - name: Snyk monitor
+              run: snyk monitor --all-projects ${INPUT_DEBUG:+ -d}
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -1,4 +1,4 @@
-name: SBT Node Snyk
+name: Simple Snyk monitor for SBT + Node
 
 on:
   workflow_call:
@@ -6,6 +6,10 @@ on:
       DEBUG:
         type: string
         required: false
+      JAVA_VERSION:
+        type: string
+        required: false
+        default: "11"
     secrets:
       SNYK_TOKEN:
         required: true
@@ -28,7 +32,7 @@ jobs:
 
             - uses: actions/setup-java@v2
               with:
-                  java-version: "11"
+                  java-version: ${{ inputs.JAVA_VERSION }}
                   distribution: "adopt"
 
             - name: Snyk monitor

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -24,10 +24,6 @@ jobs:
             - name: Checkout branch
               uses: actions/checkout@v2
 
-            - name: Setup debug var
-              run: echo INPUT_DEBUG=${{ inputs.DEBUG }} >> $GITHUB_ENV
-              shell: bash
-
             - uses: snyk/actions/setup@0.3.0
             - uses: actions/setup-node@v2
               with:
@@ -39,6 +35,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor --all-projects ${INPUT_DEBUG:+ -d}  --org="${{ inputs.ORG }}"
+              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}"
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+                  INPUT_DEBUG: ${{ inputs.DEBUG }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -6,6 +6,9 @@ on:
       DEBUG:
         type: string
         required: false
+      ORG:
+        type: string
+        required: true
       JAVA_VERSION:
         type: string
         required: false
@@ -25,6 +28,10 @@ jobs:
               run: echo INPUT_DEBUG=${{ inputs.DEBUG }} >> $GITHUB_ENV
               shell: bash
 
+            - name: Setup org var
+              run: echo INPUT_ORG=${{ inputs.ORG }} >> $GITHUB_ENV
+              shell: bash
+
             - uses: snyk/actions/setup@0.3.0
             - uses: actions/setup-node@v2
               with:
@@ -36,6 +43,6 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor --all-projects ${INPUT_DEBUG:+ -d}
+              run: snyk monitor --all-projects ${INPUT_DEBUG:+ -d}  --org=${INPUT_ORG}
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -25,8 +25,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Setup debug var
-              run: |
-                echo INPUT_DEBUG=${{ inputs.DEBUG }} >> $GITHUB_ENV
+              run: echo INPUT_DEBUG=${{ inputs.DEBUG }} >> $GITHUB_ENV
               shell: bash
 
             - uses: snyk/actions/setup@0.3.0
@@ -40,6 +39,6 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor --all-projects ${INPUT_DEBUG:+ -d}  --org=${{ inputs.ORG }}
+              run: snyk monitor --all-projects ${INPUT_DEBUG:+ -d}  --org="${{ inputs.ORG }}"
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -21,17 +21,14 @@ jobs:
               run: echo INPUT_DEBUG=${{ inputs.DEBUG }} >> $GITHUB_ENV
               shell: bash
 
-            - name: Get node version
-              run: echo NODE_VERSION=$(cat .nvmrc) >> $GITHUB_ENV
-
             - uses: snyk/actions/setup@0.3.0
             - uses: actions/setup-node@v2
               with:
-                  node-version: ${{ env.NODE_VERSION }}
+                  node-version-file: '.nvmrc'
 
             - uses: actions/setup-java@v2
               with:
-                  java-version: "8"
+                  java-version: "11"
                   distribution: "adopt"
 
             - name: Snyk monitor

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -25,11 +25,8 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Setup debug var
-              run: echo INPUT_DEBUG=${{ inputs.DEBUG }} >> $GITHUB_ENV
-              shell: bash
-
-            - name: Setup org var
-              run: echo INPUT_ORG=${{ inputs.ORG }} >> $GITHUB_ENV
+              run: |
+                echo INPUT_DEBUG=${{ inputs.DEBUG }} >> $GITHUB_ENV
               shell: bash
 
             - uses: snyk/actions/setup@0.3.0
@@ -43,6 +40,6 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor --all-projects ${INPUT_DEBUG:+ -d}  --org=${INPUT_ORG}
+              run: snyk monitor --all-projects ${INPUT_DEBUG:+ -d}  --org=${{ inputs.ORG }}
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

This PR aims to add a generic Snyk workflow which could be used across multiple projects.

The workflow uses the `snyk monitor --all-projects` command, which does a reasonable job of identifying dependency manifests within a project and can be used in cases where it is able to identify all of them successfully (this isn't always the case).

I have added a `DEBUG` input which optionally adds the `-d` argument to the Snyk command, providing more helpful logging.

## How to test

It should be possible to point other repo's workflows at this one and confirm it works as expected. [One example might be this PR](https://github.com/guardian/workflow-frontend/pull/356).

## How can we measure success?

We can avoid duplication where possible and benefit from a single point of change across the projects which consume this workflow.

