### PR TITLE
Remove references to guardian/actions-assume-aws-role

### DIFF
--- a/workflow-templates/ci-node.yml
+++ b/workflow-templates/ci-node.yml
@@ -16,7 +16,7 @@ jobs:
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
-      # required by guardian/actions-assume-aws-role
+      # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
     steps:

--- a/workflow-templates/ci-sbt-node.yml
+++ b/workflow-templates/ci-sbt-node.yml
@@ -16,7 +16,7 @@ jobs:
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
-      # required by guardian/actions-assume-aws-role
+      # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
     steps:

--- a/workflow-templates/ci-sbt.yml
+++ b/workflow-templates/ci-sbt.yml
@@ -16,7 +16,7 @@ jobs:
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
-      # required by guardian/actions-assume-aws-role
+      # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
     steps:


### PR DESCRIPTION
Follow-up to https://github.com/guardian/.github/pull/13 - I noticed a few out-of-date comments after merging that.
