### PR TITLE
Add workflow for testing PRs with Snyk

### DIFF
--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -42,7 +42,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk test
-              run: echo _${SEVERITY_THRESHOLD}_${SEVERITY_THRESHOLD:+ -d}_ && echo snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:+ high} --all-projects --org="${{ inputs.ORG }}"
+              run: echo _${SEVERITY_THRESHOLD}_${SEVERITY_THRESHOLD:- default}_ && echo snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}"
               env:
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -42,7 +42,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk test
-              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:+ high} --all-projects --org="${{ inputs.ORG }}"
+              run: echo _${SEVERITY_THRESHOLD}_${SEVERITY_THRESHOLD:+ -d}_ && echo snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:+ high} --all-projects --org="${{ inputs.ORG }}"
               env:
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -42,7 +42,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk test
-              run: echo _${SEVERITY_THRESHOLD}_${SEVERITY_THRESHOLD:- default}_ && echo snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}"
+              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}"
               env:
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -39,7 +39,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk test
-              run: echo ${INPUT_DEBUG} ${INPUT_DEBUG:+ -d} && snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=critical --all-projects --org="${{ inputs.ORG }}"
+              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=critical --all-projects --org="${{ inputs.ORG }}"
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -6,6 +6,9 @@ on:
       DEBUG:
         type: string
         required: false
+      SEVERITY_THRESHOLD:
+        type: string
+        required: false
       ORG:
         type: string
         required: true
@@ -39,7 +42,8 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk test
-              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=critical --all-projects --org="${{ inputs.ORG }}"
+              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:+ high} --all-projects --org="${{ inputs.ORG }}"
               env:
-                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
+                  SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -1,0 +1,45 @@
+name: Simple Snyk test for SBT + Node
+
+on:
+  workflow_call:
+    inputs:
+      DEBUG:
+        type: string
+        required: false
+      ORG:
+        type: string
+        required: true
+      JAVA_VERSION:
+        type: string
+        required: false
+        default: "11"
+      NODE_VERSION_FILE:
+        type: string
+        required: false
+        default: ".nvmrc"
+    secrets:
+      SNYK_TOKEN:
+        required: true
+
+jobs:
+    security:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout branch
+              uses: actions/checkout@v2
+
+            - uses: snyk/actions/setup@0.3.0
+            - uses: actions/setup-node@v2
+              with:
+                  node-version-file: ${{ inputs.NODE_VERSION_FILE }}
+
+            - uses: actions/setup-java@v2
+              with:
+                  java-version: ${{ inputs.JAVA_VERSION }}
+                  distribution: "adopt"
+
+            - name: Snyk test
+              run: echo ${INPUT_DEBUG} ${INPUT_DEBUG:+ -d} && snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=critical --all-projects --org="${{ inputs.ORG }}"
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+                  INPUT_DEBUG: ${{ inputs.DEBUG }}


### PR DESCRIPTION
## What does this change?

This adds a workflow that runs `snyk test` for scala and node projects.

The idea is that we can use this to standardise our integrating snyk with our repos.

## How to test

Currently tested in security HQ (https://github.com/guardian/security-hq/pull/423)
