### PR TITLE
Snyk action exclude

### DIFF
--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -20,6 +20,9 @@ on:
         type: string
         required: false
         default: ".nvmrc"
+      EXCLUDE:
+        type: string
+        required: false
     secrets:
       SNYK_TOKEN:
         required: true
@@ -42,7 +45,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk test
-              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}"
+              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:-high} ${INPUT_EXCLUDE:+ ${INPUT_EXCLUDE}} --all-projects --org="${{ inputs.ORG }}"
               env:
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -25,6 +25,9 @@ on:
         type: string
         required: false
         default: ".nvmrc"
+      EXCLUDE:
+        type: string
+        required: false
     secrets:
       SNYK_TOKEN:
         required: true
@@ -50,7 +53,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}"
+              run: snyk monitor ${INPUT_DEBUG:+ -d} ${INPUT_EXCLUDE:+ ${INPUT_EXCLUDE}} --all-projects --org="${{ inputs.ORG }}"
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}


### PR DESCRIPTION
## What does this change?

Adds an `EXCLUDE` parameter to the snyk actions. This comes from the requirement that we want to exclude the [`identity/build.sbt` from our project](https://github.com/guardian/frontend/blob/main/identity/build.sbt). The reason for this is Snyk can't scan it [with this error](https://github.com/guardian/frontend/runs/6192689704?check_suite_focus=true#step:6:24). 

I am assuming (and still digging into) that this is because we don't have the play context when running Snyk against that file. 

I know this is a specific case, but as it's a generic option to Snyk, might be useful to others.

## How to test

We will run it against our project and surface results (I think we can reference the hash of the action?)

## How can we measure success?

It works and DevX think it's a good option to offer.

## Have we considered potential risks?

This opens a door for people to exclude things within security scanning. This might go against what the purpose of this action is for i.e. do things well and to a standard.

This PR raises that question as well as the implementation.

