### PR TITLE
Add an exclude option to snyk workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -96,6 +96,41 @@ jobs:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 ```
 
+#### Exclude files/directories
+
+This option is a comma separated list of filenames and directory names for snyk
+to ignore from its scan. It can used to get snyk to ignore certain manifests.
+
+The behaviour is very counter-intuitive. It does not support full file paths,
+only filenames and single directory names. It will ignore any matches it finds
+in the file tree, which is to say, it will ignore any directories or any files that
+match those names.
+
+See the [documentation](https://docs.snyk.io/snyk-cli/commands/monitor#exclude-less-than-name-greater-than-less-than-name-greater-than-...greater-than)
+for more information. 
+
+```yml
+name: Snyk
+# ...
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  security:
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
+    with:
+      ORG: ~
+      EXCLUDE: file1,file2,dir1,dir
+    secrets:
+       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+```
+
 More options can be found in [the inputs of the action](sbt-node-snyk.yml#L5).
 
 # [`snyk test`](https://docs.snyk.io/snyk-cli/commands/test)

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -14,6 +14,10 @@ on:
       DEBUG:
         type: string
         required: false
+      EXCLUDE:
+        type: string
+        required: false
+        default: ""
       ORG:
         type: string
         required: true
@@ -50,7 +54,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}"
+              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}"
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}


### PR DESCRIPTION
## What does this change?

This PR adds an optional "exclude" argument. This allows client to exclude certain manifests from snyk monitor (e.g. a package.json that is used for local testing)

It is worth noting that for some reason, this argument does not support paths. Only _single_ directory names and filenames. So to ignore the file`tools/infrastructure/package.json`, setting `EXCLUDE` to this path will not work. The option is to pass `tools`, which will exclude everything inside that folder, or `package.json`, which will exclude every file that matches that name.

See https://github.com/snyk/cli/issues/2437

## How to test

Tested in the [cdk](https://github.com/guardian/cdk/blob/nori/snyv3/.github/workflows/snyk.yml) repo using

```
name: Snyk

on: push

jobs:
  security:
    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@ja-exclude
    with:
      DEBUG: true
      EXCLUDE: tools
      ORG: guardian-devtools
      SKIP_NODE: false
    secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
```