### PR TITLE
Add a `commit` tag to the snyk project

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -54,7 +54,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}"
+              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}


### PR DESCRIPTION
## What does this change?

This adds a tag with key `commit` and value set to the full commit hash that is being scanned. This is a way to "version" the dependency inventory snyk produces, and will form the basis for us to be able to determine if the snapshot is up to date with the latest changes in a repo.

In the UI it will show up like this

![Screenshot 2022-06-09 at 15 46 37](https://user-images.githubusercontent.com/1672034/172875833-050ea8e6-bb37-4f5c-8be5-e895ef9193a8.png)

## How to test

Tested in a separate branch in amiable (which is how I then got the screenshot)