### PR TITLE
Improve support for mono repos

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -54,7 +54,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
+              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA} --detection-depth=5
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -54,7 +54,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA} --detection-depth=5
+              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA} --detection-depth=8
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}


### PR DESCRIPTION
## What does this change?

Snyk only searches for manifests up to a particularly depth, and it defaults to 4. This increase the depth to 8 to better support mono repos.

Example of the paths look like in a mono repo (which originally triggered the need for this patch)

https://github.com/guardian/targeted-experiences/blob/main/braze-publishing/braze/publishing-alarm-stack-cdk/cdk/package.json


## How to test

Tested with the targeted experiences repo.