### PR TITLE
Remove the unnecessary reference to schedule Snyk

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,7 @@ A convention we have is to have these files called `.github/workflows/snyk.yml` 
 
 # [`snyk monitor`](https://docs.snyk.io/snyk-cli/commands/monitor)
 
-This action creates a project in your Snyk account to monitor open source SBT and Node vulnerabilities and license issues on a cron job.
+This action creates a project in your Snyk account to monitor open source SBT and Node vulnerabilities and license issues.
 
 ## Usage
 
@@ -26,8 +26,6 @@ See [sbt-node-snyk.yml](sbt-node-snyk.yml)
 name: Snyk
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
       - main
@@ -55,8 +53,6 @@ This will scan both SBT and Node vulnerabilities.
 name: Snyk
 # ...
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
       - main
@@ -78,8 +74,6 @@ jobs:
 name: Snyk
 # ...
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
       - main
@@ -113,8 +107,6 @@ for more information.
 name: Snyk
 # ...
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
## What does this change?

This action uses the `snyk monitor` command which sets up a project for continuous monitoring (by default once daily), so running the command on a schedule is not required.

This change updates the documentation to indicate to use an example without the `schedule` property.

## How to test

Code snippets work!

## How can we measure success?

Folk are happy that they've got the right examples (I am happy == success).