### PR TITLE
Squash merge PRs for batching if rebasing not available

### DIFF
--- a/.github/workflows/pr-batching_set-automerge.yml
+++ b/.github/workflows/pr-batching_set-automerge.yml
@@ -13,4 +13,4 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: |
-                  gh pr merge ${{ github.event.number }} --auto -d -r
+                  gh pr merge ${{ github.event.number }} --auto -d -r || gh pr merge ${{ github.event.number }} --auto -d -s


### PR DESCRIPTION
## What does this change?
In our batching workflow, this adds a fallback for the auto-merging of granular PRs such that when rebasing is not available, squash is attempted instead. This appears to be useful fairly often, e.g. after Scala Steward automatically updates (with a merge commit) PRs with changes from the target branch.