### PR TITLE
Prefer `target-reference` for identifying commits scanned by Snyk 

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -54,7 +54,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
+              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --target-reference=${GITHUB_SHA}
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}


### PR DESCRIPTION
## What does this change?
We are currently using custom tags to identify the commit ID of the scan sent to Snyk for monitoring. It allows us to periodically check that this corresponds to the latest commit of the default branch (indicating a properly set up integration).  Unfortunately we have discovered a limit of the number of unique tags that makes this method unscalable. 

Instead here we are using `target-reference` which instead appears to be a more suitable field for this information (it appears we either missed this, or it wasn't yet available). It should be noted that Snyk consider this feature to be in "open beta" still https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/grouping-projects-by-branch-or-version

