### PR TITLE
Remove Snyk project tags to avoid group limit

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -54,7 +54,7 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
+              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}"
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}


### PR DESCRIPTION
## What does this change?
Stops sending any project tags from the reusable workflow we apply to many of our github repositories. Unfortunately we've already hit a limit of 1000 tags per group, so we'll have to rethink where/how we determine whether Snyk is scanning the head of the default branch. Note: we can later add `--tags=` if we want to go back and remove previously added tags.