### PR TITLE
Correct `snyk monitor` usage docs: don't run on PRs

### DIFF
--- a/.github/workflows/docs/snyk.md
+++ b/.github/workflows/docs/snyk.md
@@ -29,7 +29,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -77,7 +76,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?
We don't typically have a need to run `snyk monitor` on a PR - it would create a recurring schedule that tests the PR's code snapshot, which is undesirable. If testing a PR is desired the instructions for `snyk test` should be followed instead.