### PR TITLE
(PR batching) Use rebase strategy to accept all changes from main

### DIFF
--- a/.github/workflows/pr-batching_tracking-branch.yml
+++ b/.github/workflows/pr-batching_tracking-branch.yml
@@ -36,5 +36,5 @@ jobs:
               run: |
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                   git config user.name "github-actions[bot]"
-                  git rebase origin/${{ inputs.DEFAULT_BRANCH }}
+                  git rebase --strategy-option ours origin/${{ inputs.DEFAULT_BRANCH }}
                   git push -f -u origin ${{ inputs.BRANCH }}


### PR DESCRIPTION
## What does this change?
If squashing one of our batched PRs, we will end up with [conflicts](https://github.com/guardian/amiable/runs/7728488532?check_suite_focus=true) when rebasing. This change selects `ours` as a merge strategy while rebasing, which counterintuitively will prioritise all changes on the default branch over the tracking branch. I've decided to add this because it makes it more resilient but also I think squashing is potentially a favourable option for PRs that contain many changes from dependency management tooling.