### PR TITLE
Clarify guidance on use of CI for dependency update PRs

### DIFF
--- a/.github/workflows/docs/pr-batching.md
+++ b/.github/workflows/docs/pr-batching.md
@@ -34,8 +34,8 @@ jobs:
     uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1
 ```
 2. Set up your dependency update tooling (e.g. [Scala Steward](https://github.com/guardian/scala-steward-public-repos)) to target this branch. By default it's called `dependency-updates`
-3. (Optional, but advised) Disable your CI from running builds on branches created by your dependency update tool. This saves time and resources, but makes it less obvious which update caused a failure if there is one.
-4. Enable auto-merge on your repository (under General settings):
+3. (Optional) Disable your CI from running builds on branches created by your dependency update tool. This saves time and resources, but makes it less obvious which update caused a failure if there is one. *N.B. If you decide to enable CI, the reusable workflow for updating doesn't currently support making it a required status check because it directly rebases the tracking branch (improvements welcome!)*
+4. Set up branch protection on the tracking branch (no specific settings are required) and enable auto-merge on your repository (under General settings):
 ![auto-merge-setting.png](auto-merge-setting.png)
 5. Create a workflow in your repository that uses the `set-automerge` workflow to merge dependency update PRs to the tracking branch when all checks have completed
 ```yaml


### PR DESCRIPTION
## What does this change?
Updates the documentation to reflect the current advice on using CI on every dependency update PR raised by Scala Steward/Dependabot. 

In the case of Scala Steward (which we run centrally) there can sometimes be failures of that central action caused by projects using the workflows in this repository to merge without CI passing. Despite the whole run being marked as a failure, it does continue to update other projects. On top of that running CI makes it easier to distinguish which updates have caused breakages.

However, the current workflow would need to be updated to accommodate CI being a required check, because it pushes a rebase directly to the tracking branch in one step. I also have some reservations about making it a required check; from a process point of view it could end up encouraging developers to ignore updates that don't work immediately. By blindly merging to a tracking branch, it may encourage devs to explicitly deal with breaking changes either by fixing, or by reverting (both of which are legitimate!)