### PR TITLE
Introduce FILE parameter

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -58,14 +58,14 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              if: inputs.FILE == ""
+              if: inputs.FILE == ''
               run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
 
             - name: Snyk monitor
-              if: inputs.FILE != ""
+              if: inputs.FILE != ''
               run: snyk monitor ${INPUT_DEBUG:+ -d} --file="${{ inputs.FILE }}" --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -57,14 +57,14 @@ jobs:
                   java-version: ${{ inputs.JAVA_VERSION }}
                   distribution: "adopt"
 
-            - name: Snyk monitor
+            - name: Snyk monitor (All projects)
               if: inputs.FILE == ''
               run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
 
-            - name: Snyk monitor
+            - name: Snyk monitor (FILE specified)
               if: inputs.FILE != ''
               run: snyk monitor ${INPUT_DEBUG:+ -d} --file="${{ inputs.FILE }}" --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
               env:

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -14,6 +14,10 @@ on:
       DEBUG:
         type: string
         required: false
+      FILE:
+        type: string
+        required: false
+        default: ""
       EXCLUDE:
         type: string
         required: false
@@ -54,7 +58,15 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
+              if: inputs.FILE == ""
               run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+                  INPUT_DEBUG: ${{ inputs.DEBUG }}
+
+            - name: Snyk monitor
+              if: inputs.FILE != ""
+              run: snyk monitor ${INPUT_DEBUG:+ -d} --file="${{ inputs.FILE }}" --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}


### PR DESCRIPTION
## What does this change?

In order to enable Snyk integrations in situations where multiple project files (e.g. `build.sbt`) exist, this optionally allows specifying which project file to use.

The `--file` param cannot be used at the same time as `--all-projects` so this workflow contains 2 jobs, one for each case.

## How do you know this works?

This is tested in the following PRs:
- https://github.com/guardian/play-secret-rotation/pull/258
- https://github.com/guardian/flexible-content/pull/4186

**Note**: It may be preferable to add another workflow specifically for the case where it is necessary to use the `FILE` param rather than having 2 similar copies of the same job.

A similar thing could be achieved by using the `--exclude` flag where a path is not required (this [will not work](https://github.com/guardian/play-secret-rotation/runs/7839414290?check_suite_focus=true#step:6:38) for some use cases).