### PR TITLE
Update documentation for batching of dependency updates

### DIFF
--- a/.github/workflows/docs/pr-batching.md
+++ b/.github/workflows/docs/pr-batching.md
@@ -4,7 +4,7 @@ There are a number of tools that automate part of the process of keeping your de
 Naturally they all have different features, but one that is currently missing from both Dependabot and Scala Steward
 (which are both popular) is the ability to combine multiple updates into a single PR.
 
-Combining PRs in this way may not be the right choice for every project. If you wish to have granular updates, each running
+*Combining PRs in this way may not be the right choice for every project*. If you wish to have granular updates, each running
 their own CI, you may wish to keep the default behaviour. At the other end of the risk and automation spectrum, you may
 be confident enough to automatically merge PRs straight to main without further review. The workflows here are 
 intended for the middle ground where it is desirable for a team member to periodically review a batch of dependency updates
@@ -20,7 +20,7 @@ To summarise:
 4. Finally this [workflow](../pr-batching_pr-tracking-branch-to-default.yml) creates a PR on a configurable schedule from the tracking branch. This PR is for manual review by the team
 
 ### How to enable
-
+**(N.B. there is a script `scripts/pr-batching.sh` to help automate the creation of these workflows. It is designed to work with [nori](https://github.com/Financial-Times/nori) or similar tools to work with multiple repositories at once.)**
 1. Create a workflow in your repository that uses the `tracking-branch` workflow to maintain a dependency update branch:
 ```yaml
 on:
@@ -47,7 +47,9 @@ on:
 jobs:
   set-automerge:
     name: Set automerge on opened PRs targeting the tracking branch
-    uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1
+    permissions:
+      contents: write
+    uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1.0.2
 ```
 6. Finally, create a workflow in your repository that uses the `pr-tracking-branch-to-default` workflow to periodically create a batch-update PR targeting your default branch:
 ```yaml
@@ -60,5 +62,9 @@ on:
 jobs:
   pr-tracking-branch:
     name: Open a PR from dependency-updates targeting main
-    uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1
+    uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1.0.2
 ```
+
+### Improvements
+1. Find an alternative to rebasing the dependency branch onto default, that allows (optional) required checks on the dependency branch (for CI.) Perhaps delete and recreate?
+2. Find a way to automatically trigger the actions for the PRs we create targeting default branch. At the moment these are not triggered because actions[bot] is used and they don't trigger workflow runs from that bot to avoid circular workflows.

--- a/.github/workflows/pr-batching_set-automerge.yml
+++ b/.github/workflows/pr-batching_set-automerge.yml
@@ -13,4 +13,4 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: |
-                  gh pr merge ${{ github.event.number }} --auto -d -r || gh pr merge ${{ github.event.number }} --auto -d -s
+                  gh pr merge ${{ github.event.number }} --auto -d -r || gh pr merge ${{ github.event.number }} --auto -d -m

--- a/.github/workflows/scripts/pr-batching.sh
+++ b/.github/workflows/scripts/pr-batching.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# A script to help with adding the necessary workflow files to enable "PR batching" for dependency updates on your
+# project(s). Intended to work with nori https://github.com/Financial-Times/nori or similar tools
+
+mkdir -p .github/workflows
+
+cat << EOF > .github/workflows/dep-updates_tracking-branch.yml
+name: Maintain dependency update batching branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-dependency-update-branch:
+    name: Keep tracking branch up to date with main
+    uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1.0.1
+EOF
+
+cat << EOF > .github/workflows/dep-updates_set-automerge.yml
+name: Set automerge on dependency update PRs
+
+on:
+  pull_request:
+    branches:
+      - dependency-updates
+
+jobs:
+  set-automerge:
+    name: Set automerge on opened PRs targeting the tracking branch
+    permissions:
+      contents: write
+    uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1.0.1
+EOF
+
+cat << EOF > .github/workflows/dep-updates_pr-tracking-branch-to-default.yml
+name: Create batch dependency update PR
+
+on:
+  schedule:
+    - cron: "35 10 1 * *"
+  # Provide support for manually triggering the workflow via GitHub.
+  workflow_dispatch:
+
+jobs:
+  pr-tracking-branch:
+    name: Open a PR from dependency-updates targeting main
+    uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1.0.1
+EOF
+
+git add .github/workflows/dep-updates_*.yml
+git commit -m 'chore: Add dependency update workflows'


### PR DESCRIPTION
## What does this change?
Updates a few things around the dependency update batching workflows:
1. Documentation updated to include required permissions for Dependabot usage
2. New "improvements" section of docs that documents some outstanding issues
3. Script for automating the addition of the workflow to a repo (or many!), and docs update to match

Separately I've also made a small tweak to the automerge settings of one of the workflows. I've switched from a "squash if rebase not available" strategy to "merge if rebase not available" because I suspect the history will be cleaner this way (commits line up better between default and tracking branch)