### PR TITLE
Support broader set of projects in reusable Snyk workflows

### DIFF
--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -32,6 +32,9 @@ on:
         type: string
         required: false
         default: ".nvmrc"
+      NODE_VERSION_OVERRIDE:
+        type: string
+        required: false
       PRUNE_DUPLICATES:
         type: boolean
         required: false
@@ -49,9 +52,14 @@ jobs:
 
             - uses: snyk/actions/setup@0.3.0
             - uses: actions/setup-node@v2
-              if: inputs.SKIP_NODE != true
+              if: inputs.NODE_VERSION_OVERRIDE == '' && inputs.SKIP_NODE != true
               with:
                   node-version-file: ${{ inputs.NODE_VERSION_FILE }}
+
+            - uses: actions/setup-node@v2
+              if: inputs.NODE_VERSION_OVERRIDE != '' && inputs.SKIP_NODE != true
+              with:
+                  node-version: ${{ inputs.NODE_VERSION_OVERRIDE }}
 
             - uses: actions/setup-java@v2
               if: inputs.SKIP_SBT != true

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         required: false
         default: true
+      SKIP_GO:
+        type: boolean
+        required: false
+        default: true
       DEBUG:
         type: string
         required: false
@@ -54,6 +58,10 @@ on:
         type: string
         required: false
         description: space-separated list of Pipfile file paths to install
+      GO_VERSION_FILE:
+        type: string
+        required: false
+        default: go.mod
     secrets:
       SNYK_TOKEN:
         required: true
@@ -106,6 +114,10 @@ jobs:
                     pipenv install
                   done 
 
+            - uses: actions/setup-go@v3
+              if: inputs.SKIP_GO != true
+              with:
+                  go-version-file: ${{ inputs.GO_VERSION_FILE }}
 
             - name: Snyk test
               run: snyk test ${INPUT_DEBUG:+ -d} ${PRUNE_DUPLICATES:+ -p} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}"  --exclude="${{ inputs.EXCLUDE }}"

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -11,6 +11,10 @@ on:
         type: boolean
         required: false
         default: false
+      SKIP_PYTHON:
+        type: boolean
+        required: false
+        default: true
       DEBUG:
         type: string
         required: false
@@ -39,6 +43,17 @@ on:
         type: boolean
         required: false
         default: false
+      PYTHON_VERSION:
+        type: string
+        required: false
+      PIP_REQUIREMENTS_FILES:
+        type: string
+        required: false
+        description: space-separated list of requirements.txt file paths to install
+      PIPFILES:
+        type: string
+        required: false
+        description: space-separated list of Pipfile file paths to install
     secrets:
       SNYK_TOKEN:
         required: true
@@ -51,6 +66,7 @@ jobs:
               uses: actions/checkout@v2
 
             - uses: snyk/actions/setup@0.3.0
+
             - uses: actions/setup-node@v2
               if: inputs.NODE_VERSION_OVERRIDE == '' && inputs.SKIP_NODE != true
               with:
@@ -66,6 +82,30 @@ jobs:
               with:
                   java-version: ${{ inputs.JAVA_VERSION }}
                   distribution: "adopt"
+
+            - uses: actions/setup-python@v4
+              if: inputs.SKIP_PYTHON != true
+              with:
+                  python-version: ${{ inputs.PYTHON_VERSION }}
+
+            - if: inputs.SKIP_PYTHON != true
+              run: pip install pipenv
+
+            - if: inputs.PIP_REQUIREMENTS_FILES != ''
+              run: |
+                  for file in ${{ inputs.PIP_REQUIREMENTS_FILES }}   
+                  do
+                    pip install -r $file
+                  done
+
+            - if: inputs.PIPFILES != ''
+              run: |
+                  for file in ${{ inputs.PIPFILES }}   
+                  do
+                    PIPENV_PIPFILE=$file
+                    pipenv install
+                  done 
+
 
             - name: Snyk test
               run: snyk test ${INPUT_DEBUG:+ -d} ${PRUNE_DUPLICATES:+ -p} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}"  --exclude="${{ inputs.EXCLUDE }}"

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -3,6 +3,14 @@ name: Simple Snyk test for SBT + Node
 on:
   workflow_call:
     inputs:
+      SKIP_NODE:
+        type: boolean
+        required: false
+        default: false
+      SKIP_SBT:
+        type: boolean
+        required: false
+        default: false
       DEBUG:
         type: string
         required: false
@@ -12,6 +20,10 @@ on:
       ORG:
         type: string
         required: true
+      EXCLUDE:
+        type: string
+        required: false
+        default: ""
       JAVA_VERSION:
         type: string
         required: false
@@ -33,16 +45,18 @@ jobs:
 
             - uses: snyk/actions/setup@0.3.0
             - uses: actions/setup-node@v2
+              if: inputs.SKIP_NODE != true
               with:
                   node-version-file: ${{ inputs.NODE_VERSION_FILE }}
 
             - uses: actions/setup-java@v2
+              if: inputs.SKIP_SBT != true
               with:
                   java-version: ${{ inputs.JAVA_VERSION }}
                   distribution: "adopt"
 
             - name: Snyk test
-              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}"
+              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}"
               env:
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -32,6 +32,10 @@ on:
         type: string
         required: false
         default: ".nvmrc"
+      PRUNE_DUPLICATES:
+        type: boolean
+        required: false
+        default: false
     secrets:
       SNYK_TOKEN:
         required: true
@@ -56,8 +60,9 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk test
-              run: snyk test ${INPUT_DEBUG:+ -d} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}"
+              run: snyk test ${INPUT_DEBUG:+ -d} ${PRUNE_DUPLICATES:+ -p} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}"  --exclude="${{ inputs.EXCLUDE }}"
               env:
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+                  PRUNE_DUPLICATES: ${{ secrets.PRUNE_DUPLICATES }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         required: false
         default: true
+      SKIP_GO:
+        type: boolean
+        required: false
+        default: true
       DEBUG:
         type: string
         required: false
@@ -51,6 +55,10 @@ on:
         type: string
         required: false
         description: space-separated list of Pipfile file paths to install
+      GO_VERSION_FILE:
+        type: string
+        required: false
+        default: go.mod
     secrets:
       SNYK_TOKEN:
         required: true
@@ -101,7 +109,12 @@ jobs:
                 do
                   PIPENV_PIPFILE=$file
                   pipenv install
-                done 
+                done
+
+            - uses: actions/setup-go@v3
+              if: inputs.SKIP_GO != true
+              with:
+                  go-version-file: ${{ inputs.GO_VERSION_FILE }}
 
             - name: Snyk monitor
               run: snyk monitor ${INPUT_DEBUG:+ -d} ${PRUNE_DUPLICATES:+ -p} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA} --

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -29,6 +29,10 @@ on:
         type: string
         required: false
         default: ".nvmrc"
+      PRUNE_DUPLICATES:
+        type: boolean
+        required: false
+        default: false
     secrets:
       SNYK_TOKEN:
         required: true
@@ -54,7 +58,8 @@ jobs:
                   distribution: "adopt"
 
             - name: Snyk monitor
-              run: snyk monitor ${INPUT_DEBUG:+ -d} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA}
+              run: snyk monitor ${INPUT_DEBUG:+ -d} ${PRUNE_DUPLICATES:+ -p} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA} --
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   INPUT_DEBUG: ${{ inputs.DEBUG }}
+                  PRUNE_DUPLICATES: ${{ inputs.PRUNE_DUPLICATES }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -1,4 +1,4 @@
-name: Simple Snyk monitor for SBT + Node
+name: Simple Snyk monitor for SBT + Node + Python
 
 on:
   workflow_call:
@@ -11,6 +11,10 @@ on:
         type: boolean
         required: false
         default: false
+      SKIP_PYTHON:
+        type: boolean
+        required: false
+        default: true
       DEBUG:
         type: string
         required: false
@@ -36,6 +40,17 @@ on:
         type: boolean
         required: false
         default: false
+      PYTHON_VERSION:
+        type: string
+        required: false
+      PIP_REQUIREMENTS_FILES:
+        type: string
+        required: false
+        description: space-separated list of requirements.txt file paths to install
+      PIPFILES:
+        type: string
+        required: false
+        description: space-separated list of Pipfile file paths to install
     secrets:
       SNYK_TOKEN:
         required: true
@@ -64,6 +79,29 @@ jobs:
               with:
                   java-version: ${{ inputs.JAVA_VERSION }}
                   distribution: "adopt"
+
+            - uses: actions/setup-python@v4
+              if: inputs.SKIP_PYTHON != true
+              with:
+                python-version: ${{ inputs.PYTHON_VERSION }}
+
+            - if: inputs.SKIP_PYTHON != true
+              run: pip install pipenv
+
+            - if: inputs.PIP_REQUIREMENTS_FILES != ''
+              run: |
+               for file in ${{ inputs.PIP_REQUIREMENTS_FILES }}   
+               do
+                 pip install -r $file
+               done
+
+            - if: inputs.PIPFILES != ''
+              run: |
+                for file in ${{ inputs.PIPFILES }}   
+                do
+                  PIPENV_PIPFILE=$file
+                  pipenv install
+                done 
 
             - name: Snyk monitor
               run: snyk monitor ${INPUT_DEBUG:+ -d} ${PRUNE_DUPLICATES:+ -p} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA} --

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -29,6 +29,9 @@ on:
         type: string
         required: false
         default: ".nvmrc"
+      NODE_VERSION_OVERRIDE:
+        type: string
+        required: false
       PRUNE_DUPLICATES:
         type: boolean
         required: false
@@ -47,9 +50,14 @@ jobs:
             - uses: snyk/actions/setup@0.3.0
 
             - uses: actions/setup-node@v2
-              if: inputs.SKIP_NODE != true
+              if: inputs.NODE_VERSION_OVERRIDE == '' && inputs.SKIP_NODE != true
               with:
                   node-version-file: ${{ inputs.NODE_VERSION_FILE }}
+
+            - uses: actions/setup-node@v2
+              if: inputs.NODE_VERSION_OVERRIDE != '' && inputs.SKIP_NODE != true
+              with:
+                  node-version: ${{ inputs.NODE_VERSION_OVERRIDE }}
 
             - uses: actions/setup-java@v2
               if: inputs.SKIP_SBT != true


### PR DESCRIPTION
## What does this change?
Adds some new features to the Snyk reusable workflows in order to support more of our projects:
1. Ability to prune duplicates, which may help with larger projects where it is not necessary to know all the paths of a duplicated dependency
2. Ability to override the node version, for projects where there is no appropriate single `.nvmrc` file to use
3. Support for python projects (both pip/requirements.txt and pipenv/Pipfile)
4. Support for go projects
5. Feature parity between the monitor and test workflows (which had been lacking recently)

Python support is slightly more involved than other ecosystems because Snyk expects dependencies to be installed (even in the presence of a Pipfile.lock.) To do so we must pass through a list of manifests, and install them in a loop.

These changes have been successfully tested on all the python projects we are currently trying to integrate with Snyk.