### PR TITLE
Fix boolean inputs to Snyk workflows

### DIFF
--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -120,9 +120,16 @@ jobs:
                   go-version-file: ${{ inputs.GO_VERSION_FILE }}
 
             - name: Snyk test
-              run: snyk test ${INPUT_DEBUG:+ -d} ${PRUNE_DUPLICATES:+ -p} --severity-threshold=${SEVERITY_THRESHOLD:-high} --all-projects --org="${{ inputs.ORG }}"  --exclude="${{ inputs.EXCLUDE }}"
+              run: |
+                snyk test \
+                  $DEBUG_OPTION \
+                  $PRUNE_OPTION \
+                  --severity-threshold=${SEVERITY_THRESHOLD:-high} \
+                  --all-projects \
+                  --org="${{ inputs.ORG }}" \
+                  --exclude="${{ inputs.EXCLUDE }}"
               env:
-                  INPUT_DEBUG: ${{ inputs.DEBUG }}
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-                  PRUNE_DUPLICATES: ${{ secrets.PRUNE_DUPLICATES }}
+                  DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
+                  PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -117,8 +117,15 @@ jobs:
                   go-version-file: ${{ inputs.GO_VERSION_FILE }}
 
             - name: Snyk monitor
-              run: snyk monitor ${INPUT_DEBUG:+ -d} ${PRUNE_DUPLICATES:+ -p} --all-projects --org="${{ inputs.ORG }}" --exclude="${{ inputs.EXCLUDE }}" --project-tags=commit=${GITHUB_SHA} --
+              run: |
+                snyk monitor \
+                  ${DEBUG_OPTION} \
+                  ${PRUNE_OPTION} \
+                  --all-projects \
+                  --org="${{ inputs.ORG }}" \
+                  --exclude="${{ inputs.EXCLUDE }}" \
+                  --project-tags=commit=${GITHUB_SHA} --
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-                  INPUT_DEBUG: ${{ inputs.DEBUG }}
-                  PRUNE_DUPLICATES: ${{ inputs.PRUNE_DUPLICATES }}
+                  DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
+                  PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}


### PR DESCRIPTION
## What does this change?
This fixes boolean inputs to the Snyk workflows which are used in `snyk` command itself via shell parameter expansion i.e. `${PARAM:+ --option}`. The end result of the expansion is always truthy/`--option` at the moment because boolean inputs in the `env` are simply strings by the time they reach the executed `run` command (bash is string based after all.)

The expansion is now a little more complicated, but I am open to simplifications if someone can spot one!

## How to test
Tested on a repo that consumes one of the workflows, using true and false and observing changing behaviour.

## How can we measure success?
No longer pruning duplicates unless requested in a parameter explicitly!