### PR TITLE
feat: Workflow template for the PR announcer

### DIFF
--- a/workflow-templates/pr-announcer.properties.json
+++ b/workflow-templates/pr-announcer.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "Guardian Google Chat PR Announcer",
+  "description": "A GitHub Action workflow to send a daily update of pull requests requiring reviews to a Google Chat space",
+  "iconName": "guardian"
+}

--- a/workflow-templates/pr-announcer.yml
+++ b/workflow-templates/pr-announcer.yml
@@ -1,0 +1,29 @@
+name: "Google Chats PR Announcer"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every morning at 6AM, Mondays to Fridays
+    - cron: "0 6 * * MON-FRI"
+
+jobs:
+  prnouncer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: guardian/actions-prnouncer@main
+        with:
+          # https://user-images.githubusercontent.com/21217225/191922153-ae6fcebe-ca87-4611-93ee-0e66a47dab5d.png
+          # Anybody can create a new Webhook for a google chatroom, press the caret by the Space name and press "Manage Webhooks"
+          # You can use any value for the name and avatar URL. You should add this secret to your repository settings.
+          google-webhook-url: ${{ secrets.GOOGLE_WEBHOOK_URL }}
+
+          # Defaults to the repository that this action is configured in.
+          # You can specify multiple repositories by using a comma delimited string!
+          # github-repositories: dotcom-rendering,frontend
+
+          # Comma delimited list of user ID's to ignore when scanning for pull requests. Defaults to Dependabot
+          # github-ignored-users: 49699333
+
+          # Comma delimited list of labels to ignore when scanning for pull requests. Defaults to "Stale".
+          # I recommend setting up the Stale PR workflow if you want to use this action.
+          # github-ignored-labels: stale

--- a/workflow-templates/pr-announcer.yml
+++ b/workflow-templates/pr-announcer.yml
@@ -15,6 +15,7 @@ jobs:
           # https://user-images.githubusercontent.com/21217225/191922153-ae6fcebe-ca87-4611-93ee-0e66a47dab5d.png
           # Anybody can create a new Webhook for a google chatroom, press the caret by the Space name and press "Manage Webhooks"
           # You can use any value for the name and avatar URL. You should add this secret to your repository settings.
+          # If you want threads to work correctly you'll need to append `&threadKey={threadKey}` to your GOOGLE_WEBHOOK_URL
           google-webhook-url: ${{ secrets.GOOGLE_WEBHOOK_URL }}
 
           # Defaults to the repository that this action is configured in.


### PR DESCRIPTION
## What does this change?

Adds a new workflow template for Dotcoms PR announcer. We've been using this action in Dotcom for months now and find it very useful to get up to speed in the mornings with PR's that need reviews.

We've found it useful to pair it with this workflow https://github.com/guardian/.github/pull/37 to automatically close PR's that are stale to prevent spam.

## Images

![image](https://user-images.githubusercontent.com/21217225/191924150-f33cd018-bb32-468a-bf57-56bffe4220c4.png)
