### PR TITLE
Add npm install for directories missing lockfiles

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -40,6 +40,10 @@ on:
       NODE_VERSION_OVERRIDE:
         type: string
         required: false
+      NODE_PACKAGE_JSON_FILES_MISSING_LOCK:
+        type: string
+        required: false
+        description: space separated list of package.json files that are missing lock files; require installation
       PRUNE_DUPLICATES:
         type: boolean
         required: false
@@ -81,6 +85,15 @@ jobs:
               if: inputs.NODE_VERSION_OVERRIDE != '' && inputs.SKIP_NODE != true
               with:
                   node-version: ${{ inputs.NODE_VERSION_OVERRIDE }}
+
+            - if: inputs.NODE_PACKAGE_JSON_FILES_MISSING_LOCK != ''
+              run: |
+                for file in ${{ inputs.NODE_PACKAGE_JSON_FILES_MISSING_LOCK }}   
+                do
+                  cd $(echo $file | sed "s/package\.json//")
+                  npm install
+                  cd -
+                done
 
             - uses: actions/setup-java@v2
               if: inputs.SKIP_SBT != true


### PR DESCRIPTION
## What does this change?
Adds an option for installing the `node_modules` for any `package.json` files without the associated `package-lock.json` (or shrinkwrap or yarn equivalent.) This is merely an option, rather than the default behaviour because best practice is to use a lock file, for reproducibility of installs and accuracy of dependency detection.