### PR TITLE
Pin Snyk workflow to working commit in snyk/actions repository 

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -74,7 +74,7 @@ jobs:
             - name: Checkout branch
               uses: actions/checkout@v2
 
-            - uses: snyk/actions/setup@0.3.0
+            - uses: snyk/actions/setup@0e928f3e9ae859e2b95ac2b89af55d7b6434244d
 
             - uses: actions/setup-node@v2
               if: inputs.NODE_VERSION_OVERRIDE == '' && inputs.SKIP_NODE != true


### PR DESCRIPTION
## What does this change?

This change pins the git ref of the Snyk action used to [this one](https://github.com/snyk/actions/commit/0e928f3e9ae859e2b95ac2b89af55d7b6434244d). That seems to download assets from Snyk rather than GitHub.

The version 0.3.0 of the action seems to have broken, see: https://github.com/guardian/cdk/actions/runs/3287939373/jobs/5417678951 

## How to test

This is used experimentally here to check it works:

https://github.com/guardian/janus/actions/runs/3288099168/jobs/5418028655

