### PR TITLE
Revert "Pin Snyk workflow to working commit in snyk/actions repository "

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -74,7 +74,7 @@ jobs:
             - name: Checkout branch
               uses: actions/checkout@v2
 
-            - uses: snyk/actions/setup@0e928f3e9ae859e2b95ac2b89af55d7b6434244d
+            - uses: snyk/actions/setup@0.3.0
 
             - uses: actions/setup-node@v2
               if: inputs.NODE_VERSION_OVERRIDE == '' && inputs.SKIP_NODE != true


### PR DESCRIPTION
Reverts guardian/.github#39

Referencing https://github.com/snyk/cli/issues/4162 as the Snyk issue.

This is now resolved: The "latest" tag used internally by the snyk action to point at particular version of the binaries in use has been moved to point at some that actually exist, so we should be able to revert this change.