### PR TITLE
Use latest checkout and cache sbt

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -72,7 +72,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout branch
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - uses: snyk/actions/setup@0.3.0
 
@@ -100,6 +100,7 @@ jobs:
               with:
                   java-version: ${{ inputs.JAVA_VERSION }}
                   distribution: "adopt"
+                  cache: 'sbt'
 
             - uses: actions/setup-python@v4
               if: inputs.SKIP_PYTHON != true


### PR DESCRIPTION
## What does this change?

Update checkout version to the latest and specify to cache sbt.
Is there a good way to test thiss branch?
