### PR TITLE
Added strict out of sync flag

### DIFF
--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -22,6 +22,11 @@ on:
       DEBUG:
         type: string
         required: false
+      STRICT_OUT_OF_SYNC:
+        type: boolean
+        required: false
+        default: true
+        description: flag for snyk to ignore any differences between package.json and package-lock.json that can't be resolved by just re-installing packages.
       SEVERITY_THRESHOLD:
         type: string
         required: false
@@ -127,7 +132,8 @@ jobs:
                   --severity-threshold=${SEVERITY_THRESHOLD:-high} \
                   --all-projects \
                   --org="${{ inputs.ORG }}" \
-                  --exclude="${{ inputs.EXCLUDE }}"
+                  --exclude="${{ inputs.EXCLUDE }}" \
+                  --strict-out-of-sync={{ inputs.STRICT_OUT_OF_SYNC }}
               env:
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -22,6 +22,11 @@ on:
       DEBUG:
         type: string
         required: false
+      STRICT_OUT_OF_SYNC:
+        type: boolean
+        required: false
+        default: true
+        description: flag for snyk to ignore any differences between package.json and package-lock.json that can't be resolved by just re-installing packages.
       EXCLUDE:
         type: string
         required: false
@@ -137,6 +142,7 @@ jobs:
                   --all-projects \
                   --org="${{ inputs.ORG }}" \
                   --exclude="${{ inputs.EXCLUDE }}" \
+                  --strict-out-of-sync={{ inputs.STRICT_OUT_OF_SYNC }} \
                   --project-tags=commit=${GITHUB_SHA} --
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -141,8 +141,8 @@ jobs:
                   ${PRUNE_OPTION} \
                   --all-projects \
                   --org="${{ inputs.ORG }}" \
+                  --strict-out-of-sync="{{ inputs.STRICT_OUT_OF_SYNC }}" \
                   --exclude="${{ inputs.EXCLUDE }}" \
-                  --strict-out-of-sync={{ inputs.STRICT_OUT_OF_SYNC }} \
                   --project-tags=commit=${GITHUB_SHA} --
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -141,7 +141,7 @@ jobs:
                   ${PRUNE_OPTION} \
                   --all-projects \
                   --org="${{ inputs.ORG }}" \
-                  --strict-out-of-sync="{{ inputs.STRICT_OUT_OF_SYNC }}" \
+                  --strict-out-of-sync=${{ inputs.STRICT_OUT_OF_SYNC }} \
                   --exclude="${{ inputs.EXCLUDE }}" \
                   --project-tags=commit=${GITHUB_SHA} --
               env:


### PR DESCRIPTION
## What does this change?

Adds a new flag to allow strict-out-of-sync option to CLI command.
This can be required if snyk gives an error saying "package.json and package-lock.json are out of sync. Re-run npm install", but re-running `npm install` does not resolve the issue.