### PR TITLE
Snyk action can use python 3

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -135,6 +135,7 @@ jobs:
                   ${DEBUG_OPTION} \
                   ${PRUNE_OPTION} \
                   --all-projects \
+                  $([[ ${PYTHON_VERSION:0:2} == 3. ]] && echo "--command=python3") \
                   --org="${{ inputs.ORG }}" \
                   --exclude="${{ inputs.EXCLUDE }}" \
                   --project-tags=commit=${GITHUB_SHA} --
@@ -142,3 +143,4 @@ jobs:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
+                  PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}


### PR DESCRIPTION
Co-authored-by Jorge <jorge.azevedo@guardian.co.uk>

## What does this change?

If a python version is provided,  the action will detect whether it is using 3.x.x or not, and modify the snyk command accordingly

## How to test

Run a snyk action on a project using python 3, verify that the project shows up in snyk

## How can we measure success?

Fewer snyk failures across our estate
