### PR TITLE
PROJECT_TAGS parameter

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -154,3 +154,4 @@ jobs:
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
                   PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}
+                  PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -63,6 +63,10 @@ on:
         type: string
         required: false
         default: go.mod
+      PROJECT_TAGS:
+        type: string
+        required: false
+        description: comma-separated list of key/value pairs for project tags, e.g. "team=devex,fun=true"
     secrets:
       SNYK_TOKEN:
         required: true
@@ -131,6 +135,12 @@ jobs:
 
             - name: Snyk monitor
               run: |
+                projectTags="commit=${GITHUB_SHA}"
+                if [ -n "${PROJECT_TAGS}" ]
+                then
+                  projectTags="$projectTags,${PROJECT_TAGS}"
+                fi
+
                 snyk monitor \
                   ${DEBUG_OPTION} \
                   ${PRUNE_OPTION} \
@@ -138,7 +148,7 @@ jobs:
                   $([[ ${PYTHON_VERSION:0:2} == 3. ]] && echo "--command=python3") \
                   --org="${{ inputs.ORG }}" \
                   --exclude="${{ inputs.EXCLUDE }}" \
-                  --project-tags=commit=${GITHUB_SHA} --
+                  --project-tags=${projectTags} --
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}


### PR DESCRIPTION
In the snyk UI it's useful to be able to filter projects by tag, e.g. a `team` tag.
This PR adds an optional parameter to the snyk workflow

[Snyk docs](https://docs.snyk.io/snyk-cli/commands/monitor#project-tags-less-than-tag-greater-than-less-than-tag-greater-than-...greater-than)

Tested with `PROJECT_TAGS: Team=MarketingTools`:
<img width="591" alt="Screenshot 2023-01-26 at 09 07 26" src="https://user-images.githubusercontent.com/1513454/214797590-f8f42fa4-243e-432f-a7f6-5a07ec06acf0.png">

<img width="422" alt="Screenshot 2023-01-26 at 09 12 44" src="https://user-images.githubusercontent.com/1513454/214798556-f90cd770-1c9a-4ef6-b7dd-90661b16ed58.png">
