### PR TITLE
fix: setup java action with cache

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -99,7 +99,7 @@ jobs:
                   cd -
                 done
 
-            - uses: actions/setup-java@v2
+            - uses: actions/setup-java@v3
               if: inputs.SKIP_SBT != true
               with:
                   java-version: ${{ inputs.JAVA_VERSION }}


### PR DESCRIPTION
## What does this change?

Fixes the change introduced in [a previously merged PR](https://github.com/guardian/.github/pull/41) by upgrading the `setup-java` action to `v3` instead of `v2`, since it looks like `v2` didn't properly support sbt in the cache parameter
https://www.scala-sbt.org/1.x/docs/GitHub-Actions-with-sbt.html#Caching

## How to test

I was using a test branch on @guardian/platform to manually run the snyk action pointing to this branch https://github.com/guardian/platform/actions/runs/4294117332/jobs/7482702261, since this is how I found out this wasn't working.

## How can we measure success?

Snyk workflows shouldn't fail on setup java with cache set to sbt now

