### PR TITLE
Add option to ignore out of sync lock files

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -162,4 +162,4 @@ jobs:
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
                   PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
-                  OUT_OF_SYNC_OPTION: ${{ inputs.IGNORE_OUT_OF_SYNC == 'true' && '--strict-out-of-sync=false' || '' }}
+                  OUT_OF_SYNC_OPTION: ${{ inputs.IGNORE_OUT_OF_SYNC == true && '--strict-out-of-sync=false' || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -67,6 +67,11 @@ on:
         type: string
         required: false
         description: comma-separated list of key/value pairs for project tags, e.g. "team=devex,fun=true"
+      IGNORE_OUT_OF_SYNC:
+        type: boolean
+        required: false
+        default: false
+        description: Set this to true to ignore out of sync errors (for npm and yarn projects)
     secrets:
       SNYK_TOKEN:
         required: true
@@ -145,6 +150,7 @@ jobs:
                 snyk monitor \
                   ${DEBUG_OPTION} \
                   ${PRUNE_OPTION} \
+                  ${OUT_OF_SYNC_OPTION} \
                   --all-projects \
                   $([[ ${PYTHON_VERSION:0:2} == 3. ]] && echo "--command=python3") \
                   --org="${{ inputs.ORG }}" \
@@ -156,3 +162,4 @@ jobs:
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
                   PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
+                  OUT_OF_SYNC_OPTION: ${{ inputs.IGNORE_OUT_OF_SYNC == 'true' && --strict-out-of-sync=false || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -162,4 +162,4 @@ jobs:
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
                   PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
-                  OUT_OF_SYNC_OPTION: ${{ inputs.IGNORE_OUT_OF_SYNC == 'true' && --strict-out-of-sync=false || '' }}
+                  OUT_OF_SYNC_OPTION: ${{ inputs.IGNORE_OUT_OF_SYNC == 'true' && '--strict-out-of-sync=false' || '' }}


### PR DESCRIPTION
## What does this change?

Because of how the [support dotcom components](https://github.com/guardian/support-dotcom-components) packages are structured the snyk task fails with the following error:
> OutOfSyncError: Dependency @sdc/shared was not found in yarn.lock. Your package.json and yarn.lock are probably out of sync. Please run "yarn install" and try again.

This PR adds support for the `--strict-out-of-sync` option for snyk monitor.
It adds a new optional boolean parameter to this task name `IGNORE_OUT_OF_SYNC`, if set to true it sets adds the option `--strict-out-of-sync=false` to the snyk command.

The default for `--strict-out-of-sync` is true so setting `IGNORE_OUT_OF_SYNC` to false does nothing.

This option is only available for npm and yarn projects.

[Snyk docs.](https://docs.snyk.io/scan-application-code/snyk-open-source/snyk-open-source-supported-languages-and-package-managers/snyk-for-javascript/snyk-for-yarn#yarn-workspaces-in-cli)

## How to test

I will use this branch's version of the task to test the support-doctom-components snyk integration and take it from there.
-> This solved the issue

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
