### PR TITLE
Remove sbt cache

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -104,7 +104,6 @@ jobs:
               with:
                   java-version: ${{ inputs.JAVA_VERSION }}
                   distribution: "adopt"
-                  cache: "sbt"
 
             - uses: actions/setup-python@v4
               if: inputs.SKIP_PYTHON != true


### PR DESCRIPTION
## What does this change?

Specifying the cache as sbt has broken this workflow in many prod repos across the estate. Example [grafana](https://github.com/guardian/grafana/actions/runs/4316031753/jobs/7531248403) and [android-news-app](https://github.com/guardian/android-news-app/actions/runs/4342846143/jobs/7584157626). There are two things at play here
- First, by specifying `cache: sbt` this workflow can no longer scan non-scala JVM projects. Of which we have a number of.
- Second, this workflow is designed to scan any and all dependencies in a repo. The way it does this is by setting up the build environment for node, java, etc and tell snyk to scan all projects in all languages it detects in a repo. This means that `setup-java` is meant to always run, regardless if a repo actually uses the jvm or not. With `cache: sbt` the workflow fails if a repo does not contain an sbt project.


## How to test

Manually ran the android snyk workflow against this branch and it fixes the issue, see https://github.com/guardian/android-news-app/actions/runs/4363581633
![Screenshot 2023-03-08 at 11 05 01](https://user-images.githubusercontent.com/1672034/223696975-23d06012-4939-4a32-a55e-98d029ddef47.png)