### PR TITLE
pipenv install should be run from the directory that the Pipfile is in

### DIFF
--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -110,8 +110,9 @@ jobs:
               run: |
                   for file in ${{ inputs.PIPFILES }}   
                   do
-                    PIPENV_PIPFILE=$file
+                    cd $(echo $file | sed "s/Pipfile//")
                     pipenv install
+                    cd -
                   done 
 
             - uses: actions/setup-go@v3

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -124,8 +124,9 @@ jobs:
               run: |
                 for file in ${{ inputs.PIPFILES }}   
                 do
-                  PIPENV_PIPFILE=$file
+                  cd $(echo $file | sed "s/Pipfile//")
                   pipenv install
+                  cd -
                 done
 
             - uses: actions/setup-go@v3


### PR DESCRIPTION
## What does this change?

This change runs the `pipenv install` from the directory of the Pipfile rather than the root directory of the project. This means that the dependencies actually get installed and so can be found when `snyk monitor....` is run in a subsequent step.

This has been shown to work on https://github.com/guardian/data-platform-models/pull/3139