### PR TITLE
Add flag to specify the target project

### DIFF
--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -140,3 +140,4 @@ jobs:
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
                   TARGET_PROJECT: ${{ inputs.FILE == '' && '--all-projects' || '--file=${{ inputs.FILE }}' }}
+                  EXCLUDE: ${{ inputs.FILE == '' && '--exclude=${{ inputs.EXCLUDE }}' || '' }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -32,7 +32,7 @@ on:
         type: string
         required: false
         default: ""
-      FILE:
+      PROJECT_FILE:
         type: string
         required: false
         default: ""
@@ -139,5 +139,5 @@ jobs:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
-                  TARGET_PROJECT: ${{ inputs.FILE == '' && '--all-projects' || '--file=${{ inputs.FILE }}' }}
-                  EXCLUDE: ${{ inputs.FILE == '' && '--exclude=${{ inputs.EXCLUDE }}' || '' }}
+                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=${{ inputs.PROJECT_FILE }}' }}
+                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${{ inputs.EXCLUDE }}' || '' }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -131,9 +131,9 @@ jobs:
                   $DEBUG_OPTION \
                   $PRUNE_OPTION \
                   --severity-threshold=${SEVERITY_THRESHOLD:-high} \
-                  --all-projects \
+                  $TARGET_PROJECT \
                   --org="${{ inputs.ORG }}" \
-                  --exclude="${{ inputs.EXCLUDE }}"
+                  $EXCLUDE"
               env:
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -32,6 +32,11 @@ on:
         type: string
         required: false
         default: ""
+      FILE:
+        type: string
+        required: false
+        default: ""
+        description: specifies the file that Snyk should inspect for package information
       JAVA_VERSION:
         type: string
         required: false

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -32,11 +32,6 @@ on:
         type: string
         required: false
         default: ""
-      PROJECT_FILE:
-        type: string
-        required: false
-        default: ""
-        description: specifies the file that Snyk should inspect for package information
       JAVA_VERSION:
         type: string
         required: false
@@ -131,13 +126,11 @@ jobs:
                   $DEBUG_OPTION \
                   $PRUNE_OPTION \
                   --severity-threshold=${SEVERITY_THRESHOLD:-high} \
-                  $TARGET_PROJECT \
+                  --all-projects \
                   --org="${{ inputs.ORG }}" \
-                  $EXCLUDE"
+                  --exclude="${{ inputs.EXCLUDE }}"
               env:
                   SEVERITY_THRESHOLD: ${{ inputs.SEVERITY_THRESHOLD }}
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
-                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=${{ inputs.PROJECT_FILE }}' }}
-                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${{ inputs.EXCLUDE }}' || '' }}

--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -139,3 +139,4 @@ jobs:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
+                  TARGET_PROJECT: ${{ inputs.FILE == '' && '--all-projects' || '--file=${{ inputs.FILE }}' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -159,5 +159,5 @@ jobs:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
-                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=${{ inputs.PROJECT_FILE }}' }}
-                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${{ inputs.EXCLUDE }}' || '' }}
+                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=${inputs.PROJECT_FILE}' }}
+                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${inputs.EXCLUDE}' || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -146,6 +146,8 @@ jobs:
                 then
                   projectTags="$projectTags,${PROJECT_TAGS}"
                 fi
+                echo "$TARGET_PROJECT"
+                echo "$EXCLUDE"
 
                 snyk monitor \
                   ${DEBUG_OPTION} \
@@ -161,5 +163,5 @@ jobs:
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
                   PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
-                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && "--all-projects" || "--file=${{ inputs.PROJECT_FILE }}" }}
-                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && "--exclude=${{ inputs.EXCLUDE }}" || '' }}
+                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=${{ inputs.PROJECT_FILE }}' }}
+                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${{ inputs.EXCLUDE }}' || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -161,5 +161,5 @@ jobs:
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
                   PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
-                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=$(inputs.PROJECT_FILE)' }}
-                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${inputs.EXCLUDE)' || '' }}
+                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && "--all-projects" || "--file=${{ inputs.PROJECT_FILE }}" }}
+                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && "--exclude=${{ inputs.EXCLUDE }}" || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -159,5 +159,7 @@ jobs:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
+                  PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}
+                  PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
                   TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=$(inputs.PROJECT_FILE)' }}
-                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=$(inputs.EXCLUDE)' || '' }}
+                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${inputs.EXCLUDE)' || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -159,5 +159,5 @@ jobs:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
-                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=${inputs.PROJECT_FILE}' }}
-                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${inputs.EXCLUDE}' || '' }}
+                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=$(inputs.PROJECT_FILE)' }}
+                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=$(inputs.EXCLUDE)' || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -26,6 +26,11 @@ on:
         type: string
         required: false
         default: ""
+      PROJECT_FILE:
+        type: string
+        required: false
+        default: ""
+        description: specifies the file that Snyk should inspect for package information
       ORG:
         type: string
         required: true
@@ -145,14 +150,14 @@ jobs:
                 snyk monitor \
                   ${DEBUG_OPTION} \
                   ${PRUNE_OPTION} \
-                  --all-projects \
+                  ${TARGET_PROJECT} \
                   $([[ ${PYTHON_VERSION:0:2} == 3. ]] && echo "--command=python3") \
                   --org="${{ inputs.ORG }}" \
-                  --exclude="${{ inputs.EXCLUDE }}" \
+                  ${EXCLUDE} \
                   --project-tags=${projectTags} --
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
                   DEBUG_OPTION: ${{ inputs.DEBUG == 'true' && '-d' || '' }}
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
-                  PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}
-                  PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
+                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=${{ inputs.PROJECT_FILE }}' }}
+                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${{ inputs.EXCLUDE }}' || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -161,5 +161,5 @@ jobs:
                   PRUNE_OPTION: ${{ inputs.PRUNE_DUPLICATES == true && '-p' || '' }}
                   PYTHON_VERSION: ${{inputs.PYTHON_VERSION}}
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
-                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || '--file=${{ inputs.PROJECT_FILE }}' }}
-                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && '--exclude=${{ inputs.EXCLUDE }}' || '' }}
+                  TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || format('--file={0}', inputs.PROJECT_FILE) }}
+                  EXCLUDE: ${{ inputs.PROJECT_FILE == '' && format('--exclude={0}', inputs.EXCLUDE) || '' }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -146,8 +146,6 @@ jobs:
                 then
                   projectTags="$projectTags,${PROJECT_TAGS}"
                 fi
-                echo "$TARGET_PROJECT"
-                echo "$EXCLUDE"
 
                 snyk monitor \
                   ${DEBUG_OPTION} \


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The PR adds a new input field called `PROJECT_FILE`, in which the file that Snyk should inspect for package information can be specified.
[Added FILE input field](https://github.com/guardian/.github/commit/17e11e6eb5a0e2587b908f985e9712e9893246ca)
[Renamed variable for clarity](https://github.com/guardian/.github/pull/54/commits/ce68ee83e4caf07f7890927cf606dbf7c3a8e573)

Also, `TARGET_PROJECT` environment variable was added to hold information about the targeted project - which can be the specified file , or `--all-projects` when the file isn't specified.
[Added TARGET_PROJECT environment variable](https://github.com/guardian/.github/commit/0f4f47af1e01b46a81c07cfb5ad1231421249e74)

Furthermore, Snyk doesn't support the `--exclude` flag when `--file` is set, so an `EXCLUDE` environment variable was added as well to hold information about the excludes.
[Added EXCLUDE environment variable](https://github.com/guardian/.github/commit/0794bb67fd99ebc1abc19438cd8d70f234d904f5)

## Context

`Gradle` projects with multiple submodules - like the Android project - appear to report some false prositives.

The reason for this is that the top level app module specifies a number of explicit versions for some further transient dependencies that the library modules themselves use, but don't necessarily care about forcing to later versions.

We don't believe we need to be looking at the granular details of each of these sub modules, we only need to be concerned with the analysis of the app module itself

Current script in `main`:
`snyk monitor --all-projects --org="guardian-mobile" --exclude="package-lock.json" --project-tags="" --  `

The script we need in a multi-module `Gradle` project:
`snyk monitor --file="./android-news-app/build.gradle.kts" --org="guardian-mobile" --project-tags="" -- `

## Tests

[Successful workflow](https://github.com/guardian/android-news-app/actions/runs/4607332841/jobs/8141719342) without `PROJECT_FILE`:

```
  projectTags="commit=${GITHUB_SHA}"
  if [ -n "${PROJECT_TAGS}" ]
  then
    projectTags="$projectTags,${PROJECT_TAGS}"
  fi
  
  snyk monitor \
    ${DEBUG_OPTION} \
    ${PRUNE_OPTION} \
    ${TARGET_PROJECT} \
    $([[ ${PYTHON_VERSION:0:2} == 3. ]] && echo "--command=python3") \
    --org="guardian-mobile" \
    ${EXCLUDE} \
    --project-tags=${projectTags} --
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/11.0.18-10/x64
    JAVA_HOME_11_X64: /opt/hostedtoolcache/Java_Adopt_jdk/11.0.18-10/x64
    SNYK_TOKEN: ***
    DEBUG_OPTION: 
    PRUNE_OPTION: 
    PYTHON_VERSION: 
    PROJECT_TAGS: 
    TARGET_PROJECT: --all-projects
    EXCLUDE: --exclude=package-lock.json
```

[Successful workflow](https://github.com/guardian/android-news-app/actions/runs/4607366554/jobs/8141795760) with `PROJECT_FILE`:

```
projectTags="commit=${GITHUB_SHA}"
  if [ -n "${PROJECT_TAGS}" ]
  then
    projectTags="$projectTags,${PROJECT_TAGS}"
  fi
  
  snyk monitor \
    ${DEBUG_OPTION} \
    ${PRUNE_OPTION} \
    ${TARGET_PROJECT} \
    $([[ ${PYTHON_VERSION:0:2} == [3](https://github.com/guardian/android-news-app/actions/runs/4607366554/jobs/8141795760#step:13:3). ]] && echo "--command=python3") \
    --org="guardian-mobile" \
    ${EXCLUDE} \
    --project-tags=${projectTags} --
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/11.0.18-10/x6[4](https://github.com/guardian/android-news-app/actions/runs/4607366554/jobs/8141795760#step:13:4)
    JAVA_HOME_11_X[6](https://github.com/guardian/android-news-app/actions/runs/4607366554/jobs/8141795760#step:13:6)4: /opt/hostedtoolcache/Java_Adopt_jdk/11.0.18-10/x64
    SNYK_TOKEN: ***
    DEBUG_OPTION: 
    PRUNE_OPTION: 
    PYTHON_VERSION: 
    PROJECT_TAGS: 
    TARGET_PROJECT: --file=./android-news-app/build.gradle.kts
    EXCLUDE:
```

## Note

I tried using the `--exclude` tag (see example script below), but it doesn't seem to work with `Gradle`. The excluded directories are still being scanned:
`snyk monitor --all-projects --org="guardian-mobile" --exclude="acquisition-events,android-news-app,bridget,build,buildSrc" --project-tags="" --project=android-news-app --`

## Warning

The repository contains identical files:
[Migrated changes into the right file](https://github.com/guardian/.github/pull/54/commits/cfe1ba3568b8bb40df3d0d612ba7becddb84b700)