### PR TITLE
Fix permissions

### DIFF
--- a/.github/workflows/pr-batching_tracking-branch.yml
+++ b/.github/workflows/pr-batching_tracking-branch.yml
@@ -1,40 +1,44 @@
 name: Set up branch to track default branch (useful for automation of dependency updates)
 
+permissions:
+  id-token: write
+  contents: write
+
 on:
-    workflow_call:
-        inputs:
-            BRANCH:
-                type: string
-                required: false
-                default: "dependency-updates"
-            DEFAULT_BRANCH:
-                type: string
-                required: false
-                default: "main"
+  workflow_call:
+    inputs:
+      BRANCH:
+        type: string
+        required: false
+        default: "dependency-updates"
+      DEFAULT_BRANCH:
+        type: string
+        required: false
+        default: "main"
 
 jobs:
-    default-tracking-branch:
-        runs-on: ubuntu-latest
-        name: Create branch or rebase it to latest default
-        steps:
-            - name: Create branch (if it does not exists)
-              env:
-                  GITHUB_TOKEN: ${{ github.token }}
-              run: |
-                  gh api --silent \
-                      /repos/${{ github.repository }}/git/refs \
-                      -f ref="refs/heads/${{ inputs.BRANCH }}" \
-                      -f sha="${{ github.sha}}" ||
-                      echo '`${{ inputs.BRANCH }}` branch already exists on ${{ github.repository }}'
-            - name: Checkout tracking branch
-              uses: actions/checkout@v2
-              with:
-                  ref: ${{ inputs.BRANCH }}
-                  fetch-depth: 0
+  default-tracking-branch:
+    runs-on: ubuntu-latest
+    name: Create branch or rebase it to latest default
+    steps:
+      - name: Create branch (if it does not exists)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh api --silent \
+              /repos/${{ github.repository }}/git/refs \
+              -f ref="refs/heads/${{ inputs.BRANCH }}" \
+              -f sha="${{ github.sha}}" ||
+              echo '`${{ inputs.BRANCH }}` branch already exists on ${{ github.repository }}'
+      - name: Checkout tracking branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.BRANCH }}
+          fetch-depth: 0
 
-            - name: Rebase tracking branch to latest origin default
-              run: |
-                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                  git config user.name "github-actions[bot]"
-                  git rebase --strategy-option ours origin/${{ inputs.DEFAULT_BRANCH }}
-                  git push -f -u origin ${{ inputs.BRANCH }}
+      - name: Rebase tracking branch to latest origin default
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git rebase --strategy-option ours origin/${{ inputs.DEFAULT_BRANCH }}
+          git push -f -u origin ${{ inputs.BRANCH }}


### PR DESCRIPTION
Our default permissions appear to have changed following a trial of Github Enterprise to allow read only, which is breaking this workflow. E.g. see:

https://github.com/guardian/riff-raff/actions/runs/5047026696
https://github.com/guardian/amiable/actions/runs/5046679858

This commit explicitly sets write permissions as required.

See also:

*
https://docs.github.com/en/enterprise-cloud@latest/admin/policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#enforcing-a-policy-for-workflow-permissions-in-your-enterprise
* https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

