### PR TITLE
Tag snyk projects with full repository name

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -141,7 +141,7 @@ jobs:
 
             - name: Snyk monitor
               run: |
-                projectTags="commit=${GITHUB_SHA}"
+                projectTags="commit=${GITHUB_SHA},repo=${{ github.repository }}"
                 if [ -n "${PROJECT_TAGS}" ]
                 then
                   projectTags="$projectTags,${PROJECT_TAGS}"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

A project on snyk is not the same thing as a repo. One project is one manifest file and all it's dependencies. If you have a monorepo, or a multilanguage repo, snyk interprets each of it's composite parts as an independent project.

Tagging each project with the repo it came from comes with a number of benefits

- Better developer experience. Developers don't have to learn about snyk's model for repos/projects. They just look at the tags to figure out where a project came from
- Easier integration with service catalogue. Having the repo name as a project tag means we can easily join with the github and cloudformation tables (if a stack was provisioned with GuCDK, it will have a gu:repo tag).
- We already tag the commit hash. Those hashes are easier to hunt down if you have the additional context of the repo name

## How to test

On a repo with this workflow enabled, switch to the `nt/add-repo-tag` version of the action and verify the new tag shows up on snyk

## How can we measure success?

Much easier to tell where a project came from with less clicking around.

## Have we considered potential risks?

### Which name to use
Would we be better off using the long or short repo name (ie guardian/abc vs abc)? I would lean towards the long one for completeness' sake but can be persuaded otherwise.

### Tag limits
Snyk has a finite unique tag limit. This will increase the number of tags in use my a few hundred. However the limit is 5000, and we are currently using about 350, tagging the project with the commit hash. The number of repos should be more or less equal to the number of commit hashes, so I expect we'll see our tag count increase to about 700, well under the 5000 limit.

## Images

<img width="388" alt="a screenshot from snyk showing that the new tag shows up on the UI" src="https://github.com/guardian/.github/assets/67543397/b1261cef-c18f-42a5-9eed-301c5b6623fc">

