### PR TITLE
Update batching workflow with permissions

### DIFF
--- a/.github/workflows/docs/pr-batching.md
+++ b/.github/workflows/docs/pr-batching.md
@@ -30,6 +30,9 @@ on:
 
 jobs:
   update-dependency-update-branch:
+    permissions:
+      id-token: write
+      contents: write
     name: Keep tracking branch up to date with main
     uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1
 ```

--- a/.github/workflows/docs/pr-batching.md
+++ b/.github/workflows/docs/pr-batching.md
@@ -52,7 +52,7 @@ jobs:
     name: Set automerge on opened PRs targeting the tracking branch
     permissions:
       contents: write
-      pull-requests: write # only for private repositories
+      pull-requests: write
     uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1.0.2
 ```
 6. Finally, create a workflow in your repository that uses the `pr-tracking-branch-to-default` workflow to periodically create a batch-update PR targeting your default branch:

--- a/.github/workflows/docs/pr-batching.md
+++ b/.github/workflows/docs/pr-batching.md
@@ -67,6 +67,9 @@ jobs:
   pr-tracking-branch:
     name: Open a PR from dependency-updates targeting main
     uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1.0.2
+    permissions:
+      contents: write
+      pull-requests: write
 ```
 
 ### Improvements

--- a/.github/workflows/scripts/pr-batching.sh
+++ b/.github/workflows/scripts/pr-batching.sh
@@ -35,6 +35,7 @@ jobs:
     name: Set automerge on opened PRs targeting the tracking branch
     permissions:
       contents: write
+      pull-requests: write
     uses: guardian/.github/.github/workflows/pr-batching_set-automerge.yml@v1.0.1
 EOF
 

--- a/.github/workflows/scripts/pr-batching.sh
+++ b/.github/workflows/scripts/pr-batching.sh
@@ -15,6 +15,9 @@ on:
 
 jobs:
   update-dependency-update-branch:
+    permissions:
+      id-token: write
+      contents: write
     name: Keep tracking branch up to date with main
     uses: guardian/.github/.github/workflows/pr-batching_tracking-branch.yml@v1.0.1
 EOF

--- a/.github/workflows/scripts/pr-batching.sh
+++ b/.github/workflows/scripts/pr-batching.sh
@@ -52,6 +52,9 @@ jobs:
   pr-tracking-branch:
     name: Open a PR from dependency-updates targeting main
     uses: guardian/.github/.github/workflows/pr-batching_pr-tracking-branch-to-default.yml@v1.0.1
+    permissions:
+      contents: write
+      pull-requests: write
 EOF
 
 git add .github/workflows/dep-updates_*.yml


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

### `update-dependency-update-branch` workflow
* Adds permissions to the example code and setup script for the `dep-updates_tracking-branch.yml` workflow.
* Changes to the Github Actions settings in the organisation mean that this workflow needs explicit permissions to be granted now. I've modelled the changes in this PR on a PR to RiffRaff to fix this issue: https://github.com/guardian/riff-raff/pull/1160

### `dep-updates_pr-tracking-branch-to-default` workflow

* Adds permissions to the example code and setup script for the `dep-updates_pr-tracking-branch-to-default.yml` workflow.
* I haven't found a passing version of this yet ([RiffRaff is failing](https://github.com/guardian/riff-raff/actions/workflows/dep-updates_pr-tracking-branch-to-default.yml), for instance) but both `contents: write` and `pull-requests: write` permissions seem to be necessary for the job to succeed on the (private) repo I'm working on atm.

### `set-automerge` workflow

Adds `pull-request: write` permission to the setup script for this workflow. It was mentioned as being needed for private repos only in the docs, but the job is failing on permissions issues in e.g.:

* RiffRaff's [workflow is failing](https://github.com/guardian/riff-raff/actions/runs/5220640948/jobs/9423963905)
* [Amigo](https://github.com/guardian/amigo/actions/workflows/dep-updates_set-automerge.yml)


It seems to be passing on [Prism](https://github.com/guardian/prism/blob/main/.github/workflows/dep-updates_set-automerge.yml), though, so I'm not 100% sure on this one.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I ran the new setup script and have verified that it produces a workflow file that matches expectations (identical to e.g. the RiffRaff file above). It also matches the example in the docs file (except for the version number for the remote workflow; that discrepancy already existed though so I thought it best to leave it as it is).

