### PR TITLE
Adds the --dev option to Snyk checks

### DIFF
--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -123,6 +123,7 @@ jobs:
             - name: Snyk test
               run: |
                 snyk test \
+                  --dev \
                   $DEBUG_OPTION \
                   $PRUNE_OPTION \
                   --severity-threshold=${SEVERITY_THRESHOLD:-high} \

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -148,6 +148,7 @@ jobs:
                 fi
 
                 snyk monitor \
+                  --dev \
                   ${DEBUG_OPTION} \
                   ${PRUNE_OPTION} \
                   ${TARGET_PROJECT} \


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR aims to improve overall vulnerability visibility by including devDepencides in Snyk checks. This defaults to false but can be set using the `--dev` option: https://docs.snyk.io/snyk-cli/commands/monitor#dev

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
We can check this in another repo by pointing to this branch's workflow. 

-  ❌ Ran using Ophan: https://github.com/guardian/ophan/actions/runs/5509454187/jobs/10042187882 but failed with exit code 2

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Vulnerabilities from devDependencies are reported to Snyk and can be viewed in the Snyk Dashboard. 

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Are issues with devDependencies a lower priority than production dependency issues? Will including them significantly increase the number of dependencies which requires attention?
