### PR TITLE
Add branch tag. Add debug warning.

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -22,6 +22,7 @@ on:
       DEBUG:
         type: string
         required: false
+        description: Setting this flag to true will break scala and python projects. Deprecated.
       EXCLUDE:
         type: string
         required: false
@@ -141,7 +142,7 @@ jobs:
 
             - name: Snyk monitor
               run: |
-                projectTags="commit=${GITHUB_SHA},repo=${{ github.repository }}"
+                projectTags="commit=${GITHUB_SHA},repo=${{ github.repository }},branch=${GITHUB_REF#refs/heads/}"
                 if [ -n "${PROJECT_TAGS}" ]
                 then
                   projectTags="$projectTags,${PROJECT_TAGS}"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Adding the branch name will make it easier for us (and cloudquery) to see if a production repo's main branch is on snyk
- We shouldn't be recommending that people use debug mode, as it breaks all scala builds.

## How to test

Use a repo with a snyk.yml/yaml. Switch the branch name referenced from main to nt/inputs and run the action.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

This introduces new distinct tags, taking us closer to our tag limit. A unique key:value pair counts as one tag, regardless of how many projects it's applied to. The vast majority of repos use main/master as default branch names. This means that the best case scenario is that our tag count increases by two. If someone runs the snyk action on a branch other than master/main, that will use up a tag, but it will be cleared within a day of another run on the default branch.

Also, our tag limit is 5000 and we are only using about 700 at the moment, so we have quite a lot of headroom.

## Images

<img width="252" alt="Screenshot 2023-11-07 at 07 54 05" src="https://github.com/guardian/.github/assets/67543397/d51cb7c1-d2aa-4992-ae2d-d0851da2870c">

