### PR TITLE
Make snyk monitor use the path as the project name

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -32,11 +32,6 @@ on:
         required: false
         default: ""
         description: specifies the file that Snyk should inspect for package information
-      PROJECT_NAME:
-        type: string
-        required: false
-        default: ""
-        description: specifies the project name override to use in snyk, if required
       ORG:
         type: string
         required: true
@@ -170,4 +165,4 @@ jobs:
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
                   TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || format('--file={0}', inputs.PROJECT_FILE) }}
                   EXCLUDE: ${{ inputs.PROJECT_FILE == '' && format('--exclude={0}', inputs.EXCLUDE) || '' }}
-                  PROJECT_NAME_OPTION: ${{ inputs.PROJECT_NAME == '' && format('--project-name={0}', inputs.PROJECT_NAME) }}
+                  PROJECT_NAME_OPTION: ${{ inputs.PROJECT_FILE == '' && format('--project-name={0}/{1}', ${{ github.repository }}, inputs.PROJECT_FILE) }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -165,4 +165,4 @@ jobs:
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
                   TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || format('--file={0}', inputs.PROJECT_FILE) }}
                   EXCLUDE: ${{ inputs.PROJECT_FILE == '' && format('--exclude={0}', inputs.EXCLUDE) || '' }}
-                  PROJECT_NAME_OPTION: ${{ inputs.PROJECT_FILE == '' && format('--project-name={0}/{1}', ${{ github.repository }}, inputs.PROJECT_FILE) }}
+                  PROJECT_NAME_OPTION: ${{ inputs.PROJECT_FILE == '' && format('--project-name={0}/{1}', github.repository, inputs.PROJECT_FILE) }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -165,4 +165,4 @@ jobs:
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
                   TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || format('--file={0}', inputs.PROJECT_FILE) }}
                   EXCLUDE: ${{ inputs.PROJECT_FILE == '' && format('--exclude={0}', inputs.EXCLUDE) || '' }}
-                  PROJECT_NAME_OPTION: ${{ inputs.PROJECT_FILE == '' && format('--project-name={0}/{1}', github.repository, inputs.PROJECT_FILE) }}
+                  PROJECT_NAME_OPTION: ${{ inputs.PROJECT_FILE == '' && '' || format('--project-name={0}/{1}', github.repository, inputs.PROJECT_FILE) }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -154,7 +154,7 @@ jobs:
                   ${TARGET_PROJECT} \
                   $([[ ${PYTHON_VERSION:0:2} == 3. ]] && echo "--command=python3") \
                   --org="${{ inputs.ORG }}" \
-                  ${PROJECT_NAME_OPTION}
+                  ${PROJECT_NAME_OPTION} \
                   ${EXCLUDE} \
                   --project-tags=${projectTags} --
               env:

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -32,6 +32,11 @@ on:
         required: false
         default: ""
         description: specifies the file that Snyk should inspect for package information
+      PROJECT_NAME:
+        type: string
+        required: false
+        default: ""
+        description: specifies the project name override to use in snyk, if required
       ORG:
         type: string
         required: true
@@ -154,6 +159,7 @@ jobs:
                   ${TARGET_PROJECT} \
                   $([[ ${PYTHON_VERSION:0:2} == 3. ]] && echo "--command=python3") \
                   --org="${{ inputs.ORG }}" \
+                  ${PROJECT_NAME_OPTION}
                   ${EXCLUDE} \
                   --project-tags=${projectTags} --
               env:
@@ -164,3 +170,4 @@ jobs:
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
                   TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || format('--file={0}', inputs.PROJECT_FILE) }}
                   EXCLUDE: ${{ inputs.PROJECT_FILE == '' && format('--exclude={0}', inputs.EXCLUDE) || '' }}
+                  PROJECT_NAME_OPTION: ${{ inputs.PROJECT_NAME == '' && format('--project-name={0}', inputs.PROJECT_NAME) }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -165,4 +165,4 @@ jobs:
                   PROJECT_TAGS: ${{inputs.PROJECT_TAGS}}
                   TARGET_PROJECT: ${{ inputs.PROJECT_FILE == '' && '--all-projects' || format('--file={0}', inputs.PROJECT_FILE) }}
                   EXCLUDE: ${{ inputs.PROJECT_FILE == '' && format('--exclude={0}', inputs.EXCLUDE) || '' }}
-                  PROJECT_NAME_OPTION: ${{ inputs.PROJECT_FILE == '' && '' || format('--project-name={0}/{1}', github.repository, inputs.PROJECT_FILE) }}
+                  PROJECT_NAME_OPTION: ${{ inputs.PROJECT_FILE == '' && '' || format('--project-name={0}', inputs.PROJECT_FILE) }}


### PR DESCRIPTION
This PR makes the snyk monitor action use <build-filename> as the project name if a build file name is specified.
This means that if you don't need the auto-detecting facility where snyk goes and finds all the projects and uploads them separately, you can tie down the project name to something reasonable.

Behold the old (not great), default (terrible) and new (brill) names

<img width="704" alt="image" src="https://github.com/guardian/.github/assets/7304387/b9a2e4a9-7142-4431-99f5-8ec033403e87">


The good thing is this kind of matches up with how snyk recommend in their documentation
![image](https://github.com/guardian/.github/assets/7304387/197273b7-7c25-49ed-b728-e23cdc73030c)
(from https://docs.snyk.io/snyk-admin/introduction-to-snyk-projects )

The downside is people have to specify the build file to get the benefits of it, and it will affect a couple of other existing projects, so we will need to let them know in case it causes a similar confusion in case this changes (improves?) their project name. https://github.com/search?q=org%3Aguardian+PROJECT_FILE+snyk&type=code