### PR TITLE
Update Snyk Workflows To Use `actions/setup-node@v4`

### DIFF
--- a/.github/workflows/sbt-node-snyk-pr.yml
+++ b/.github/workflows/sbt-node-snyk-pr.yml
@@ -75,12 +75,12 @@ jobs:
 
             - uses: snyk/actions/setup@0.3.0
 
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v4
               if: inputs.NODE_VERSION_OVERRIDE == '' && inputs.SKIP_NODE != true
               with:
                   node-version-file: ${{ inputs.NODE_VERSION_FILE }}
 
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v4
               if: inputs.NODE_VERSION_OVERRIDE != '' && inputs.SKIP_NODE != true
               with:
                   node-version: ${{ inputs.NODE_VERSION_OVERRIDE }}

--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -86,12 +86,12 @@ jobs:
 
             - uses: snyk/actions/setup@0.3.0
 
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v4
               if: inputs.NODE_VERSION_OVERRIDE == '' && inputs.SKIP_NODE != true
               with:
                   node-version-file: ${{ inputs.NODE_VERSION_FILE }}
 
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v4
               if: inputs.NODE_VERSION_OVERRIDE != '' && inputs.SKIP_NODE != true
               with:
                   node-version: ${{ inputs.NODE_VERSION_OVERRIDE }}


### PR DESCRIPTION
This version runs on Node 20, the active LTS.

Release notes for this action can be found here: https://github.com/actions/setup-node/releases

Release notes specifically for the two major releases we're bumping across can be found here:

- v3.0.0: https://github.com/actions/setup-node/releases/tag/v3.0.0
- v4.0.0: https://github.com/actions/setup-node/releases/tag/v4.0.0

Aside from the Node upgrade, the other breaking change appears to be removing the `version` input, which we don't use here. There are also some dependency updates.
