### PR TITLE
Set Up Dependabot For Workflows Directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     directory: "workflow-templates/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    # Automatically picks up `/.github/workflows` as specified in the docs:
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Allows dependabot to open PRs that update actions used in `/.github/workflows`. This should mean automated PRs for changes like #72.

This may not be what is wanted for this repo. The creation of the `dependabot.yml` in #55 specifically targeted the `workflow-templates` directory, not `/.github/workflows`.

@NovemberTang please let me know if this isn't something we should be adding!
