### PR TITLE
feat: add dependency-graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -8,5 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: scalacenter/sbt-dependency-submission@v2
-    permissions:
-        contents: write # this permission is needed to submit the dependency graph
+   

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,12 @@
+name: Update Dependency Graph
+on:
+  workflow_call:
+jobs:
+  dependency-graph-sbt:
+    name: Update Dependency Graph for SBT
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: scalacenter/sbt-dependency-submission@v2
+    permissions:
+        contents: write # this permission is needed to submit the dependency graph


### PR DESCRIPTION
## What does this change?

Adds a `dependency-graph` workflow that currently submits sbt dependencies to Github so that Scala deps can be tracked by Dependabot. The idea is to add other workflows to this file in the future that will run selectively depending on the language of the repo.

## How to test

This was [tested on janus-app](https://github.com/guardian/janus-app/compare/main...ts/use-central-dependency-workflow) by modifiying the existing dependency-graph.yml to point to this workflow. The [action ran successfully](https://github.com/guardian/janus-app/actions/runs/8066265727) and produced [a dependency graph snapshot](https://api.github.com/repos/guardian/janus-app/dependency-graph/snapshots/11091869).

## How can we measure success?

We can add to and update this workflow in one place, and it will be updated on all repos that use it.

## Have we considered potential risks?

Once we add more languages , we will need to ensure that the workflow on a repo doesn't run unnecessarily for languages that are not in the repo.
