### PR TITLE
make java 21 the default for snyk workflow

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -38,7 +38,7 @@ on:
       JAVA_VERSION:
         type: string
         required: false
-        default: "11"
+        default: "21"
       NODE_VERSION_FILE:
         type: string
         required: false


### PR DESCRIPTION
I noticed that java 11 is the default, but now our recommendation is java 21 (although java 11 is still acceptable as a minumim) see https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit#heading=h.gnp9lqaztaf .  I noticed this when we were doing this PR https://github.com/guardian/support-service-lambdas/pull/2218

This might break some older projects?  But scala-steward uses java 21 - https://github.com/guardian/scala-steward-public-repos/pull/67 (although check how many comments further down mention issues!) , so we could prompt it (especially given the perf improvements of java 21 over 11)

Happy to go either way on this PR, we can be bold and merge it (with comms?) or be cautious, since breaking snyk checks can cause the checks to stop, without it being totally obvious.