### PR TITLE
Explicitly install sbt in the snyk workflow

### DIFF
--- a/.github/workflows/sbt-node-snyk.yml
+++ b/.github/workflows/sbt-node-snyk.yml
@@ -110,6 +110,9 @@ jobs:
               with:
                   java-version: ${{ inputs.JAVA_VERSION }}
                   distribution: "adopt"
+            
+            - uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+              if: inputs.SKIP_SBT != true
 
             - uses: actions/setup-python@v5
               if: inputs.SKIP_PYTHON != true


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Explicitly installs sbt on the `sbt-node-snyk`  workflow which is referenced by the Snyk worfklows on individual repos. The latest versiof of Ubuntu no longer installs this dependency by default.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Tested on security-hq [before](https://github.com/guardian/security-hq/actions/runs/11345385386) and [after](https://github.com/guardian/security-hq/actions/runs/11346879153).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

The Snyk workflows should run successfully on repos as they're currently failing.
