### PR TITLE
fix(stale-template): Support non-public repositories

### DIFF
--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -19,6 +19,8 @@ jobs:
         id: stale
         # Read about options here: https://github.com/actions/stale#all-options
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
           # never automatically mark issues as stale
           days-before-issue-stale: -1
 

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -26,7 +26,7 @@ jobs:
           days-before-stale: 30
           stale-pr-message: >
             This PR is stale because it has been open 30 days with no activity.
-            Unless a comment is added or the “stale” label removed, this will be closed in 3 days
+            Unless a comment is added or the “stale” label removed, this will be closed in 3 days.
 
           # Wait 3 days after a PR has been marked as stale before closing
           days-before-close: 3


### PR DESCRIPTION
## What does this change?

Updates the stale workflow template so that it works with public, internal and private[^1] repositories. This is after noticing the implementation in [guardian/deploy-tools-platform](https://github.com/guardian/deploy-tools-platform/blob/ee0907f96cd60c9cfe1c2fde09ccb90768413947/.github/workflows/stale.yml) has been [failing, since forever](https://github.com/guardian/deploy-tools-platform/actions/workflows/stale.yml)!

See also https://github.com/actions/stale/issues/585.

[^1]: https://github.com/guardian/data-platform-models/pull/5887 for an example.