### PR TITLE
Revert "only run core4 check on non-draft PRs"

### DIFF
--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -8,7 +8,6 @@ permissions:
   
 jobs:
   require-label:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-slim
     steps:
       - name: Check for required label


### PR DESCRIPTION
Reverts guardian/.github#110

This change resulted in an issue where the action was updated and no longer checked draft PRs as expected, but the trigger (`ready_for_review`) was never added to the check-label.yaml file.

PRs raised as draft were then not checked on becoming non-draft, and PRs were not compliant with organisational requirements.

If this PR is re-reverted, it should have a script provided which will create the necessary PRs in all repos to add the trigger.