### PR TITLE
Add workflow to require consistent tool versions

### DIFF
--- a/.github/workflows/require-constent-tool-versions.yaml
+++ b/.github/workflows/require-constent-tool-versions.yaml
@@ -1,0 +1,50 @@
+name: Require PR Label
+
+on:
+  workflow_call:
+
+permissions: 
+  contents: read
+  
+jobs:
+  require-consistent-tool-versions:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for consistent versions
+        run: |
+          FAIL=0
+          
+          check() {
+            local tool=$1; shift
+            versions="$(printf '%s\n' "$@" | sort -u | xargs)"
+            versionCount="$(echo "$versions" | wc -w)"
+            echo "$tool: $versions"
+            (( $versionCount < 2 )) && return 0
+            FAIL=1
+          }
+          
+          tv() { awk -v t="$1" '$1==t{print $2}' .tool-versions 2>/dev/null; }
+          
+          # Could add .node-version, package.json and more ...
+          check node \
+            "$(sed 's/^v//' .nvmrc 2>/dev/null | tr -d '[:space:]')" \
+            "$(tv nodejs)" \
+            "$(tv node)" 
+          
+          # Could add .sdkmanrc, jenv, and move
+          check java \
+            "$(cat .java-version 2>/dev/null | tr -d '[:space:]')" \
+            "$(tv java)" 
+          
+          check scala \
+            "$(sed 's|//.*||' build.sbt 2>/dev/null | grep scalaVersion | cut -d'"' -f2 | tr -d '[:space:]')" \
+            "$(tv scala)" 
+          
+          check sbt \
+            "$(awk -F= '/^sbt\.version=/ {print $2}' project/build.properties 2>/dev/null)" \
+            "$(tv sbt)" 
+          
+          exit $FAIL
+

--- a/.github/workflows/require-constent-tool-versions.yaml
+++ b/.github/workflows/require-constent-tool-versions.yaml
@@ -3,9 +3,9 @@ name: Require PR Label
 on:
   workflow_call:
 
-permissions: 
+permissions:
   contents: read
-  
+
 jobs:
   require-consistent-tool-versions:
     runs-on: ubuntu-slim
@@ -14,37 +14,53 @@ jobs:
 
       - name: Check for consistent versions
         run: |
-          FAIL=0
-          
+          local FAIL=0
+
+          versions_match() {
+            printf '%s\n' "$@" | sort -V | awk -F. '
+              NR>1 {
+                for(i=1;i<=n;i++)
+                  if ($i!=a[n]) exit 1
+              }
+              {
+                 n=NF;
+                 split($0, a, ".")
+              }
+            '
+          }
+
           check() {
             local tool=$1; shift
-            versions="$(printf '%s\n' "$@" | sort -u | xargs)"
-            versionCount="$(echo "$versions" | wc -w)"
-            echo "$tool: $versions"
-            (( $versionCount < 2 )) && return 0
+            echo "$tool has versions: $@"
+            if versions_match "$@"; then
+              echo "$tool versions are consistent"
+              FAIL=0
+              return
+            fi
+            echo "$tool versions are inconsistent"
             FAIL=1
           }
-          
+
           tv() { awk -v t="$1" '$1==t{print $2}' .tool-versions 2>/dev/null; }
-          
+
           # Could add .node-version, package.json and more ...
           check node \
             "$(sed 's/^v//' .nvmrc 2>/dev/null | tr -d '[:space:]')" \
             "$(tv nodejs)" \
-            "$(tv node)" 
-          
+            "$(tv node)"
+
           # Could add .sdkmanrc, jenv, and move
           check java \
             "$(cat .java-version 2>/dev/null | tr -d '[:space:]')" \
-            "$(tv java)" 
-          
+            "$(tv java)"
+
           check scala \
             "$(sed 's|//.*||' build.sbt 2>/dev/null | grep scalaVersion | cut -d'"' -f2 | tr -d '[:space:]')" \
-            "$(tv scala)" 
-          
+            "$(tv scala)"
+
           check sbt \
             "$(awk -F= '/^sbt\.version=/ {print $2}' project/build.properties 2>/dev/null)" \
-            "$(tv sbt)" 
-          
+            "$(tv sbt)"
+
           exit $FAIL
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR provides a protective workflow to ensure node / java / scala / sbt versions are all consistent in the multiple places they can be specified.  This is to prevent adding, for example, "xxx latest" to .tool-versions when there is a specific version in use in the project already by some other mechanism. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
