### PR TITLE
chore: Update CODEOWNERS syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @guardian/devx-reliability-and-ops
-* @guardian/devx-security
+* @guardian/devx-reliability-and-ops @guardian/devx-security


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/.github/pull/125 has been assigned one CODEOWNER review even though two are listed in CODEOWNERS.

Looking at other repositories where we have multi-team code ownership, it looks like the correct syntax is `file pattern -> owning team(s)`. Where we have the same file pattern on multiple lines, the last one wins.

This updates the CODEOWNERS syntax to match https://github.com/guardian/service-catalogue/blob/main/.github/CODEOWNERS to test this hypothesis.