### PR TITLE
docs: Link to engineering site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Default health files
 
-Default community health files for the Guardian's Product and Engineering department.
+Default community health files for the [Guardian's Product and Engineering department](https://theguardian.engineering/).
 
 For more info: 
 


### PR DESCRIPTION
A small change to check if https://github.com/guardian/.github/pull/126 worked.